### PR TITLE
Pretty-print the command in shell-friendly notation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,7 @@ Test command line utilities and applications by whitelisting them with app-speci
     >>> tester = Runner()
     >>> tester.call_engines['echo'] = SubprocessValidator()
     >>> tester.teststring(test_str)
+    # echo 'Pining for the fjords'
 
 Click applications
 ~~~~~~~~~~~~~~~~~~
@@ -93,6 +94,7 @@ This can now be tested in docstrings:
     ... 
     ...     $ hello Polly Parrot
     ...     Usage: hello [OPTIONS] NAME
+    ...     Try "hello --help" for help.
     ...     <BLANKLINE>
     ...     Error: Got unexpected extra argument (Parrot)
     ... 
@@ -110,6 +112,9 @@ Click applications can be tested with a ``ClickValidator`` engine:
     >>> tester.call_engines['hello'] = ClickValidator(hello)
 
     >>> tester.teststring(test_str)
+    # hello Polly
+    # hello Polly Parrot
+    # hello 'Polly Parrot'
 
 
 Mixed applications
@@ -147,6 +152,10 @@ Your app can be combined with other command-line utilities by adding multiple en
     >>> tester.call_engines['cat'] = SubprocessValidator()
 
     >>> tester.teststring(test_str)
+    # hello Polly
+    # echo 'Pining for the fjords'
+    # python -c "with open('tmp.txt', 'w+') as f: f.write('Pushing up daisies')"
+    # cat tmp.txt
 
 Suppressing commands
 ~~~~~~~~~~~~~~~~~~~~
@@ -158,7 +167,7 @@ Commands can be skipped altogether with a ``SkipValidator``:
     >>> test_str = '''
     ... .. code-block:: bash
     ... 
-    ...     $ aws storage buckets list
+    ...     $ aws storage buckets list --password $MY_PASSWORD
     ... 
     ... '''
 
@@ -166,6 +175,7 @@ Commands can be skipped altogether with a ``SkipValidator``:
     >>> tester.call_engines['aws'] = SkipValidator()
 
     >>> tester.teststring(test_str)
+    # aws storage ...
 
 
 Illegal commands
@@ -217,6 +227,7 @@ Unrecognized commands will not raise an error if +SKIP is specified
     ...
     ... '''
     >>> tester.teststring(test_str)
+    # nmake all
 
 Error handling
 ~~~~~~~~~~~~~~
@@ -239,10 +250,9 @@ Lines failing to match the command's output will raise an error
     >>> tester.teststring(test_str) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
     ...
-    ValueError: Clatter test failed. There, it moved!
-     != "No it didn't!"
-    + There, it moved!
-    - "No it didn't!"
+    ValueError: Differences (ndiff with -expected +actual):
+        - "No it didn't!"
+        + There, it moved!
 
 Known issues
 ------------
@@ -272,10 +282,9 @@ All arguments to commands are passed as arguments to the first command. Therefor
     >>> tester.teststring(test_str) # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
     Traceback (most recent call last):
     ...
-    ValueError: Clatter test failed. hello > test.txt
-     != 
-    + hello > test.txt
-    - 
+    ValueError: Differences (ndiff with -expected +actual):
+        + hello > test.txt
+    <BLANKLINE>
 
 
 

--- a/clatter/core.py
+++ b/clatter/core.py
@@ -90,12 +90,17 @@ class Runner(object):
         '''
 
         for command, expected, options in self._parse_cli_statement(command):
+            end = None
+            pretty = '# {}'
             if 'password' in ' '.join(command):
                 # Ignore anything after 1st arg so passwords are not
                 # shown.
-                print(">>> {} ...".format(command[0:2]))
-            else:
-                print(">>> {}".format(command))
+                end = 2
+                pretty += ' ...'
+
+            # Pretty-print the command in shell-friendly notation
+            quote = lambda x: repr(x) if ' ' in x else str(x)  # noqa: E731
+            print(pretty.format(' '.join(quote(x) for x in command[0:end])))
 
             if options & doctest.SKIP:
                 continue

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -40,6 +40,7 @@ def test_string_command():
 
         $ hello Polly Parrot
         Usage: hello [OPTIONS] NAME
+        Try "hello --help" for help.
         <BLANKLINE>
         Error: Got unexpected extra argument (Parrot)
 


### PR DESCRIPTION
When tests fail, it's highly useful to be able to copy+paste the command that was run.

Get the unit tests passing again, while I'm in there.